### PR TITLE
Update build

### DIFF
--- a/bin/templates/scripts/strapkit/build
+++ b/bin/templates/scripts/strapkit/build
@@ -110,12 +110,12 @@ function PebbleBuild (){
 
 function CreateBuildDir (){
 	local projRootDir=$1
-
-	if [ ! -d "$projRootDir/build/" ]; then
-		mkdir -v "$projRootDir/build/"
-		if [ ! -d "$projRootDir/build/pebble" ]; then
-			mkdir -v "$projRootDir/build/pebble"
+	
+	if [ ! -d "$projRootDir/build/pebble" ]; then
+		if [ ! -d "$projRootDir/build/" ]; then
+			mkdir -v "$projRootDir/build/"
 		fi
+		mkdir -v "$projRootDir/build/pebble"
 	fi
 }
 


### PR DESCRIPTION
Fixed Issue where if `$projRootDir/build` directory exists but `$projRootDir/build/pebble` doesn't, the `$projRootDir/build/pebble` directory is not created.
